### PR TITLE
support all outputs and verbose option

### DIFF
--- a/check_selenium_docker.py
+++ b/check_selenium_docker.py
@@ -24,7 +24,7 @@ import glob
 parser = argparse.ArgumentParser()
 parser.add_argument("--timeout", type=int, default=300, help="results waiting timeout in sec, default 300")
 parser.add_argument('--verbose', '-v', action='count', default=0,
-    help="show failed test names and failure messages (-vv)")
+    help="show failed tests names and failure messages (-vv)")
 parser.add_argument("path", type=str, help="path to selenium test")
 args = parser.parse_args()
 path = args.path

--- a/check_selenium_docker.py
+++ b/check_selenium_docker.py
@@ -22,9 +22,9 @@ import glob
 
 # Parse commandline arguments
 parser = argparse.ArgumentParser()
+parser.add_argument('-v', '--verbose', action='count', default=0,
+    help="show failed test names and failure messages (-vv)")
 parser.add_argument("--timeout", type=int, default=300, help="results waiting timeout in sec, default 300")
-parser.add_argument('--verbose', '-v', action='count', default=0,
-    help="show failed tests names and failure messages (-vv)")
 parser.add_argument("path", type=str, help="path to selenium test")
 args = parser.parse_args()
 path = args.path


### PR DESCRIPTION
CHANGELOG
- wait for and processing all json output files
- calculate `exec_time` based on execution all tests in all suites from all side files
-  aggregated `passed`, `failed`, and `total` counters for all tests
-  verbose option for more [Nagios Guidelines](https://nagios-plugins.org/doc/guidelines.html#PLUGOUTPUT) compliant error output 
